### PR TITLE
Remove unused variable `Dimentions`

### DIFF
--- a/imagefudge/image_fudge.py
+++ b/imagefudge/image_fudge.py
@@ -10,7 +10,6 @@ from collections import namedtuple
 class Fudged(object):
     """ """
     Point = namedtuple('Point', ['x', 'y'])
-    Dimention = namedtuple('Dimention', ['width', 'height'])
 
     def __init__(self, image):
         try:


### PR DESCRIPTION
- Originally just wanted to fix the typo.
- Discovered that `Dimentions` is declared but never used.
- `self.width` and `self.height` are used instead.
